### PR TITLE
Use php file_exists instead of Illuminate\Filesystem::exists.

### DIFF
--- a/src/ServiceAutoloader.php
+++ b/src/ServiceAutoloader.php
@@ -2,7 +2,6 @@
 
 namespace BrightComponents\Service;
 
-use Illuminate\Support\Facades\File;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
@@ -40,7 +39,7 @@ class ServiceAutoloader
      */
     public function load()
     {
-        if (File::exists($directory = $this->translator::$definitions)) {
+        if (file_exists($directory = $this->translator::$definitions)) {
             if (Config::get('servicehandler.cache')) {
                 return Cache::rememberForever(Config::get('servicehandler.cache_key'), function () use ($directory) {
                     return $this->loadServicesFromDirectory($directory);


### PR DESCRIPTION
Using the filesystem facade, File, creates a dependency on Illuminate\Filesystem. Since ```File``` was only used once in one file, it was swapped with the built-in php function 'file_exists'.